### PR TITLE
externpro 25.07.6-88-gb05bee7

### DIFF
--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,0 +1,2 @@
+tag: v2.7.6.5
+message: "externpro version 2.7.6.5 tag"

--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,2 +1,2 @@
-tag: v2.7.6.5
-message: "externpro version 2.7.6.5 tag"
+tag: xpv2.7.6.6
+message: "xpro version 2.7.6.6 tag"

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -1,12 +1,12 @@
-name: Build
+name: xpBuild
 permissions:
   contents: read
   pull-requests: write
 on:
   push:
-    branches: [ "dev" ]
+    tags: ["xpv*"]
   pull_request:
-    branches: [ "dev" ]
+    branches: ["xpro"]
   workflow_dispatch:
 jobs:
   linux:
@@ -14,17 +14,17 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.3
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.6
     with:
       cmake-workflow-preset: LinuxRelease
     secrets: inherit
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.3
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.6
     with:
       cmake-workflow-preset: DarwinRelease
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.3
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.6
     with:
       cmake-workflow-preset: WindowsRelease
     secrets: inherit

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -1,4 +1,4 @@
-name: Release
+name: xpRelease
 on:
   workflow_dispatch:
     inputs:
@@ -6,10 +6,35 @@ on:
         description: 'URL of the workflow run containing artifacts to upload (e.g., https://github.com/owner/repo/actions/runs/123456789)'
         required: true
         type: string
+  workflow_run:
+    workflows: ["xpBuild"]
+    types: [completed]
 jobs:
+  dispatch-at-tag:
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'xpv')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      -
+        name: Dispatch xpRelease at tag
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          TAG_REF: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          gh api -X POST "repos/${{ github.repository }}/actions/workflows/xprelease.yml/dispatches" \
+            -f ref="$TAG_REF" \
+            -f inputs[workflow_run_url]="$RUN_URL"
   # Upload build artifacts as release assets
   release-from-build:
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.3
+    if: github.event_name == 'workflow_dispatch'
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.6
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -1,0 +1,16 @@
+name: xpTag
+permissions:
+  contents: write
+  issues: write
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  tag:
+    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
+    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.6
+    with:
+      merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
+      pr_number: ${{ github.event.pull_request.number }}
+    secrets:
+      workflow_write_token: ${{ secrets.XPUPDATE_TOKEN }}


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.6-88-gb05bee7`

## Changes

- Updated `.devcontainer` to externpro `25.07.6-88-gb05bee7`
- Previous HEAD: `6ecb6efd2c51ff0f83638817b0d3dbb8fbdc87b9`
- New HEAD: `b05bee72bf7b2b09fe21b2247e5d322d1667529f`
- Created `.github/release-tag.yml` (tag: `v2.7.6.5`)
- If you add the \"release:tag\" label, the tag will be \`v2.7.6.5\`
  - WARNING: that tag already exists; update \".github/release-tag.yml\" to the next desired tag value
    - https://github.com/externpro/patch/blob/externpro-update-25.07.6-88-gb05bee7-21915968903-1/.github/release-tag.yml
- Updated caller workflows to match templates

### Workflow Update Report

✓ xpbuild.yml: Version updated 25.07.3 → 25.07.6
✓ xpbuild.yml: workflow name updated from template
✓ xpbuild.yml: push.branches updated from template
✓ xpbuild.yml: push.tags updated from template
✓ xpbuild.yml: pull_request.branches updated from template

### Preserved Customizations
🔧 cmake-workflow-preset: LinuxRelease,DarwinRelease,WindowsRelease
🔧 cmake-workflow-preset: LinuxRelease,DarwinRelease,WindowsRelease
🔧 cmake-workflow-preset: LinuxRelease,DarwinRelease,WindowsRelease
✓ xprelease.yml: Synced from template
✓ xptag.yml: Created new workflow from template

---

*This PR was created automatically by GitHub Actions*
